### PR TITLE
Add option to share only old.reddit links

### DIFF
--- a/src/components/CompactPost.vue
+++ b/src/components/CompactPost.vue
@@ -94,8 +94,9 @@ async function handle_touch(event) {
 }
 
 async function share() {
+    let redditDomain = (JSON.parse(localStorage.getItem("share_old_reddit")) ? "https://old.reddit.com" : "https://www.reddit.com";
     await Share.share({
-        url: "https://www.reddit.com" + props.post.permalink,
+        url: redditDomain + props.post.permalink,
     });
 }
 

--- a/src/components/CompactPost.vue
+++ b/src/components/CompactPost.vue
@@ -94,7 +94,7 @@ async function handle_touch(event) {
 }
 
 async function share() {
-    let redditDomain = (JSON.parse(localStorage.getItem("share_old_reddit")) ? "https://old.reddit.com" : "https://www.reddit.com";
+    let redditDomain = JSON.parse(localStorage.getItem("share_old_reddit")) ? "https://old.reddit.com" : "https://www.reddit.com";
     await Share.share({
         url: redditDomain + props.post.permalink,
     });

--- a/src/components/FullPost.vue
+++ b/src/components/FullPost.vue
@@ -73,7 +73,7 @@ const props = defineProps({
 })
 
 async function share() {
-    let redditDomain = (JSON.parse(localStorage.getItem("share_old_reddit"))) ? "https://old.reddit.com" : "https://www.reddit.com";
+    let redditDomain = JSON.parse(localStorage.getItem("share_old_reddit")) ? "https://old.reddit.com" : "https://www.reddit.com";
     await Share.share({
         url: redditDomain + props.post.data.permalink,
     });

--- a/src/components/FullPost.vue
+++ b/src/components/FullPost.vue
@@ -73,8 +73,9 @@ const props = defineProps({
 })
 
 async function share() {
+    let redditDomain = (JSON.parse(localStorage.getItem("share_old_reddit"))) ? "https://old.reddit.com" : "https://www.reddit.com";
     await Share.share({
-        url: "https://www.reddit.com" + props.post.data.permalink,
+        url: redditDomain + props.post.data.permalink,
     });
 }
 

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -44,7 +44,7 @@
                 </span>
             </div>
             <div class="list-item dps-16">
-                <span class="body-large">Share old reddit links</span>
+                <span class="body-large">Share old.reddit links</span>
                 <span class="list-item-trailing-icon">
                     <div class="switch" :state="share_old_reddit ? 'on' : 'off'" @click.passive="change_old_reddit">
                         <div class="switch-container">

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -43,6 +43,16 @@
                     </div>
                 </span>
             </div>
+            <div class="list-item dps-16">
+                <span class="body-large">Share old reddit links</span>
+                <span class="list-item-trailing-icon">
+                    <div class="switch" :state="share_old_reddit ? 'on' : 'off'" @click.passive="change_old_reddit">
+                        <div class="switch-container">
+                            <span class="material-icons"></span>
+                        </div>
+                    </div>
+                </span>
+            </div>
         </div>
         <div class="divider"></div>
         <div class="d-flex flex-column text-4 dpy-16">
@@ -103,6 +113,7 @@ const autoplay = ref(null);
 const title_size = ref(null);
 const check_for_updates = ref(null);
 const in_app_browser = ref(null);
+const share_old_reddit = ref(null);
 
 async function open_github() {
     window.open("https://github.com/kaangiray26/geddit-app", "_blank");
@@ -134,10 +145,16 @@ async function change_browser() {
     localStorage.setItem("in_app_browser", JSON.stringify(in_app_browser.value));
 }
 
+async function change_old_reddit() {
+    share_old_reddit.value = !share_old_reddit.value;
+    localStorage.setItem("share_old_reddit", JSON.stringify(share_old_reddit.value));
+}
+
 onBeforeMount(() => {
     autoplay.value = JSON.parse(localStorage.getItem("autoplay"));
     check_for_updates.value = JSON.parse(localStorage.getItem("check_for_updates"));
     in_app_browser.value = JSON.parse(localStorage.getItem("in_app_browser"));
+    share_old_reddit.value = JSON.parse(localStorage.getItem("share_old_reddit"));
     title_size.value = JSON.parse(localStorage.getItem("title_size"));
 })
 </script>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -35,7 +35,7 @@ if (!localStorage.getItem("in_app_browser")) {
 }
 
 if (!localStorage.getItem("share_old_reddit")) {
-    localStorage.setItem("share_old_reddit", JSON.stringify(true));
+    localStorage.setItem("share_old_reddit", JSON.stringify(false));
 }
 
 // Set options

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -34,6 +34,10 @@ if (!localStorage.getItem("in_app_browser")) {
     localStorage.setItem("in_app_browser", JSON.stringify(true));
 }
 
+if (!localStorage.getItem("share_old_reddit")) {
+    localStorage.setItem("share_old_reddit", JSON.stringify(true));
+}
+
 // Set options
 document.body.setAttribute("autoplay", JSON.parse(localStorage.getItem("autoplay")));
 


### PR DESCRIPTION
Hi,
I, and my friends have been using your app since the shutdown of boost,
we share a lot of posts between us, but Geddit app takes us to new reddit, which promotes reddit app, and does not work well with firefox.
So I added a flag in settings to use old.reddit.
Thought of sharing it here.