### PR TITLE
Change touchstart event listeners to click #57

### DIFF
--- a/src/components/TopAppBarSubreddit.vue
+++ b/src/components/TopAppBarSubreddit.vue
@@ -26,18 +26,18 @@
         </div>
     </div>
     <div class="d-flex dps-16 dpb-16 md-background">
-        <div class="chips-container" @touchstart.stop="open_dialog">
+        <div class="chips-container" @click.stop="open_dialog">
             <span class=" material-icons">sort</span>
             <span class="label-large">{{ display }}</span>
         </div>
     </div>
-    <div class="dialog" v-show="dialog_visible" @touchstart.stop="close_dialog">
+    <div class="dialog" v-show="dialog_visible" @click.stop="close_dialog">
         <div class="dialog-container">
             <div class="dialog-title">
                 <span class="headline-small">Sort options</span>
             </div>
             <div v-show="tab == 'sort'" class="list-container py-0">
-                <div class="list-item" v-for="sort_type in sort_types" @touchstart.stop="change_sort(sort_type)">
+                <div class="list-item" v-for="sort_type in sort_types" @click.stop="change_sort(sort_type)">
                     <div class="list-item-leading-icon">
                         <span class="material-icons">{{ sort_type.icon }}</span>
                     </div>
@@ -49,7 +49,7 @@
                 </div>
             </div>
             <div v-show="tab == 'time'" class="list-container py-0">
-                <div class="list-item" v-for="time_type in time_types" @touchstart.stop="change_time(time_type)">
+                <div class="list-item" v-for="time_type in time_types" @click.stop="change_time(time_type)">
                     <div class="list-item-leading-icon">
                         <span class="material-icons">{{ time_type.icon }}</span>
                     </div>


### PR DESCRIPTION
Fix for issue #57 [Clicking "sort by" dropdown while over subreddit "following" button clicks both buttons #57
](https://github.com/kaangiray26/geddit-app/issues/57)

The problem was that right after you select a sort_type or time_type, the 'Follow' (or 'Following') button gets clicked since the .dialog element disappears immediately after touching it (they had touchstart event listener). The .stop (for stopping propagation) doesn't help in the case. I think because the 'Follow' button has a different event listener (click). That's because I have tried changing the 'Follow' button's listener to touchstart, and it worked! But I decided not to use this solution because it becomes very easy to click accidentally when starting to scroll.

The solution that I applied is changing the touchstart event listeners to click event listners for the .dialog element and it's clickable children. I changed all of them because triggering e.g. a sort_type click event, instantly triggers it's parent's touchstart event. That is because, if I understood correctly, click events don't stop propagation
 of touchstart (only click events).